### PR TITLE
Changed to use under score when the model name is plural.

### DIFF
--- a/app/views/rails_admin/main/dropzone.html.haml
+++ b/app/views/rails_admin/main/dropzone.html.haml
@@ -8,7 +8,7 @@
     if ($(".dropzone").length){
       var dropzone = new Dropzone (".dropzone", {
         maxFilesize: 256, // Set the maximum file size to 256 MB
-        paramName: "#{@object.class.to_s.downcase}[second_attr][]", // Rails expects the file upload to be something like model[field_name]
+        paramName: "#{@object.model_name.param_key}[second_attr][]", // Rails expects the file upload to be something like model[field_name]
         addRemoveLinks: false, // Don't show remove links on dropzone itself.
         // Translations
         dictDefaultMessage: "#{I18n.t('admin.actions.dropzone.dictDefaultMessage')}",


### PR DESCRIPTION
#39 